### PR TITLE
automate compilation and publishing of binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,21 +14,23 @@ addons:
 
 env:
   global:
-    - secure: Ql22+1A3r6/PBB12R0B+j0Vg7V+YaBm3hGe7l5ERxywQR4/HcdWNg/VRcc7YmmuMIli6SltJxjflPozkHuH1UGEyz4yfkRMIeZo2Zf8OIFJOZujvoZeCNlJABXFHaTwHzoXJqMHEUjP69il2PSGt6FLdTWvzGoE5aIOeF1k6JPM71dBtkwH0Op3aBF2ausTzuyxtf+gkbYD+ybrHkioModTK+1jQvTeoYzSOnElEHErb7Jh0AQ9o0UQVKnqWduxRgNzhNjtoIKNB/F2B6Q3bXDFtUF1KbzNxk3zhAPvlEc8DY/km19LcSu+o9GXCrnbbsUqzGMgnA1UdVbQvJI7QM2NFJjAbeXHJV6auUhtr/KWnDQePJv5bqg+AhnWiFtSDKVTW2+zgIgzt7rWm9xEMxLd4Za9BpWroGZ9N3d9ycHviYEbtNdTX5IN0oLcU38UBbHBRGplzVprNhCsyKdqpulN3sPUQoBZTgYdS2LOJnLanbqomqvtkwGa7DLtiVS0SmlsmGQIDM63fr5RKYvFLp8SifcQ1NzWsKocOI7DCxPoLwSrmZCn9bzk2AeeMA6LFCVSR8FWGXcxJSRpQyhoUoFCxvKRVEqx/fsPLpJgng68WITVT/qzoKgyLlN7g8DwmScLfMnLnSiO5RZibd1e9zwIhHL1xEJEAMJS0ApjZpXc=
-    - secure: gCY4DvkwHexxfReo8q4yzPVhxivNOKKkPoVhO+EEptmDb77JRHjSYuNWFDdoVKvyTufJcqOqK6shwiF7iBrsVXPFevCiXiLM5j+B+3f7Of3ytkMkV5uwlv7xGvWlP5GEI0UQtm9B1LOPd63hWxzLcUgtbEYfK1Li+vLPIclx2MKZ7nBRMpQtzENEuw0TyeoQ4xY4tqVs0qgMrHUQkk5LSw3r+wMYD8pgcB4Xa19Ugck69XnYkEwoxy/f0JzMcC6OF8GIZiqKpgDMjK11AJPUKVIDvnBuWoRww04kCmeoUYyk64PrieJaV/mvKxT/NIFqSJx2lDoPdPUIPpTMhtpwkGqBKYjIcOOUAE470rnpOTdfZu9PohvJOGGz5DE9WkIUeYkpbD+5aqIEpnNuRphbnfCftONVhwJhV6E9vyLdDGk1+HRg6ypbE/n4STACk/T0CeuUggHyH4KwpPOFin9IKJLWTcAYqBGcCD1hhj6XzqlARJlFvuExA5L/s0KWqgOYiqo/T7q7dWN3iHbo8De68JoCKimm54Zz6y6i77+GfRisBhX49UTcX4kxQK3K8bfTQd1O//6kYOMWZVixLOcBxCmS4R5pjNejj+UK9ZHv0U8NRzd3p1PBBmYqi4Gb73WxzT0TDWxmO2hYTEbFm/cbGQuoovMCHPryVcmdsestiYY=
-  - CXX=g++-4.8
+    - secure: A8ieqjLOvpEBcuDKFwEURNLtY9rUT73THx3ym8hnitPBq6ZPrAZ31QjZ55i8vywek+L8YrjcbR3PBZmyiey33TEfN1Z7a3USYB/j1erhYMTsIX3zmqYazhMbeMNAOrh1T5/ei9tlp1nTtYiXNbVbncPBnGYhkhNKHzPgacAm5n29DkeGk4bg333LUXvrxq0ZMFcGCsx3gdPro83HF/gSxQPLJQubAgOFljbHtwa2pTmQprI9IbdcZbh/mEfc3zwqt9zPYT2Pu/gWqMctVkfSaSIyGNVAsmkIMS6iSovwdjJmXhuFxyfhSqNXKR4x+Ha00ELoTD71Oey8VV+CdcVLoVPLMtkw9qai7nrfknWj4Bw+6zwcIkvCWkQ5YuB6SpJUvjf3ZqANU3VaNEbEdzifolMRGkY0i18ivViWe/q78535JLMXFqLtHWy7AusbvGq86TyG9eeP9mTvtD5XSYWUw64vMyCBFJpMfOf1m7XZYKsQ4K8sXiMW9ZbCKKFr78t6wqchSRH5pVocpuPX3T3Ck/w7CMk89MTZP02GsXMzJ4wEKIcLrrne19Z3iGgTXIxNQJ3E+7M/E0NQrWeXRgN4cznhONhGS7I2E3V2TB4ygTsSYoWpA78WDMcGqakL2QWi1goX5wOrdATOnZMtR1SKHP/nSkpm3Z9jJxjufU8pXsw=
+    - secure: W+BvS3DEpZh6oEQL0r0ZfCQy7VsukyQE+39VuKeqseQA5Fa9f7K0bB9X+iTt2EJGYpZx+QWX1z+mtmw1Mfp1q83w2jtf7n4ysyM4ttAlvR5lLKkgOhYBCYiwAb7WBknMck0ub2Nw6pf4NBlkJGvtcZWRfsefBqOHQh5mRh+gLMouSVj+p6mBPtvKdbH9z16cFm5KPBH32+7VAwRaNKsgY9Go4JG1DT5jt/2Et+rUfyeuK9DdRSnmdzjRvWLwpzHeaWGk2i92K04C+R9Ej7Wrf6QyoHvNN2bdEMLUHIR1iuBQbM1/R16WSOSU3YCYY9gMcQiPj+BFjZs/OuzD63m1yZxmtmlTYJ7CZqGa80wHdUnGkgVlshFpObLgqySRBGhlU+wxiR4oM/N2S1Ek0qxrFBjQLKwkZ6ObqiSU5uObxLiDn00kmiInI+1tRRSsE05FRMj78YPar1pgqODQY1iEfIf5WP97tS7TXzWdAHhNrl/sH+2qvsvzbJZe8qQbH84nZ8qNdl4OD4m4kD2YDmQu7Tpl4eQMyTrd1Ehan8oUxM/FUgCxJ6j2TTfb9v6TYGf5S7PuY/oSwSrgbDWu0U/WfV+s2pQBisuT3Oze52d+vVRe3B/WFT1IwhcrOP0lEL3rfccSjZ5ayd/tPr8yrZCJwB3+8DNg8QBXpN6uRVBbeY4=
+    - CXX=g++-4.8
 
 matrix:
   fast_finish: true
 
 before_install:
   - export PATH=./node_modules/.bin/:$PATH
-  - PUBLISH_BINARY=true
+  - npm install node-gyp -g
+  - PUBLISH_BINARY=false
   - if [[ $TRAVIS_BRANCH == `git describe --tags --always HEAD` ]]; then PUBLISH_BINARY=true; fi;
   - if test "${COMMIT_MESSAGE#*'[publish binary]'}" != "$COMMIT_MESSAGE"; then PUBLISH_BINARY=true; fi;
 
 install:
   - npm install --build-from-source
+  - npm test
 
 before_script:
   - echo "Publishing native platform Binary Package? ->" $PUBLISH_BINARY

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 
 before_install:
   - export PATH=./node_modules/.bin/:$PATH
-  - npm install node-gyp -g
+  - npm install -g node-gyp
   - PUBLISH_BINARY=false
   - if [[ $TRAVIS_BRANCH == `git describe --tags --always HEAD` ]]; then PUBLISH_BINARY=true; fi;
   - if test "${COMMIT_MESSAGE#*'[publish binary]'}" != "$COMMIT_MESSAGE"; then PUBLISH_BINARY=true; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,34 @@ addons:
       - g++-4.8
 
 env:
+  global:
+    - secure: Ql22+1A3r6/PBB12R0B+j0Vg7V+YaBm3hGe7l5ERxywQR4/HcdWNg/VRcc7YmmuMIli6SltJxjflPozkHuH1UGEyz4yfkRMIeZo2Zf8OIFJOZujvoZeCNlJABXFHaTwHzoXJqMHEUjP69il2PSGt6FLdTWvzGoE5aIOeF1k6JPM71dBtkwH0Op3aBF2ausTzuyxtf+gkbYD+ybrHkioModTK+1jQvTeoYzSOnElEHErb7Jh0AQ9o0UQVKnqWduxRgNzhNjtoIKNB/F2B6Q3bXDFtUF1KbzNxk3zhAPvlEc8DY/km19LcSu+o9GXCrnbbsUqzGMgnA1UdVbQvJI7QM2NFJjAbeXHJV6auUhtr/KWnDQePJv5bqg+AhnWiFtSDKVTW2+zgIgzt7rWm9xEMxLd4Za9BpWroGZ9N3d9ycHviYEbtNdTX5IN0oLcU38UBbHBRGplzVprNhCsyKdqpulN3sPUQoBZTgYdS2LOJnLanbqomqvtkwGa7DLtiVS0SmlsmGQIDM63fr5RKYvFLp8SifcQ1NzWsKocOI7DCxPoLwSrmZCn9bzk2AeeMA6LFCVSR8FWGXcxJSRpQyhoUoFCxvKRVEqx/fsPLpJgng68WITVT/qzoKgyLlN7g8DwmScLfMnLnSiO5RZibd1e9zwIhHL1xEJEAMJS0ApjZpXc=
+    - secure: gCY4DvkwHexxfReo8q4yzPVhxivNOKKkPoVhO+EEptmDb77JRHjSYuNWFDdoVKvyTufJcqOqK6shwiF7iBrsVXPFevCiXiLM5j+B+3f7Of3ytkMkV5uwlv7xGvWlP5GEI0UQtm9B1LOPd63hWxzLcUgtbEYfK1Li+vLPIclx2MKZ7nBRMpQtzENEuw0TyeoQ4xY4tqVs0qgMrHUQkk5LSw3r+wMYD8pgcB4Xa19Ugck69XnYkEwoxy/f0JzMcC6OF8GIZiqKpgDMjK11AJPUKVIDvnBuWoRww04kCmeoUYyk64PrieJaV/mvKxT/NIFqSJx2lDoPdPUIPpTMhtpwkGqBKYjIcOOUAE470rnpOTdfZu9PohvJOGGz5DE9WkIUeYkpbD+5aqIEpnNuRphbnfCftONVhwJhV6E9vyLdDGk1+HRg6ypbE/n4STACk/T0CeuUggHyH4KwpPOFin9IKJLWTcAYqBGcCD1hhj6XzqlARJlFvuExA5L/s0KWqgOYiqo/T7q7dWN3iHbo8De68JoCKimm54Zz6y6i77+GfRisBhX49UTcX4kxQK3K8bfTQd1O//6kYOMWZVixLOcBxCmS4R5pjNejj+UK9ZHv0U8NRzd3p1PBBmYqi4Gb73WxzT0TDWxmO2hYTEbFm/cbGQuoovMCHPryVcmdsestiYY=
   - CXX=g++-4.8
 
 matrix:
   fast_finish: true
+
+before_install:
+  - export PATH=./node_modules/.bin/:$PATH
+  - PUBLISH_BINARY=true
+  - if [[ $TRAVIS_BRANCH == `git describe --tags --always HEAD` ]]; then PUBLISH_BINARY=true; fi;
+  - if test "${COMMIT_MESSAGE#*'[publish binary]'}" != "$COMMIT_MESSAGE"; then PUBLISH_BINARY=true; fi;
+
+install:
+  - npm install --build-from-source
+
+before_script:
+  - echo "Publishing native platform Binary Package? ->" $PUBLISH_BINARY
+  - if [[ $PUBLISH_BINARY == true ]]; then node-pre-gyp package publish || true ; fi;
+  - node-pre-gyp clean
+  - node-gyp clean
+
+script:
+  - INSTALL_RESULT=0
+  - if [[ $PUBLISH_BINARY == true ]]; then INSTALL_RESULT=$(npm install --fallback-to-build=false > /dev/null)$? || true; fi;
+  - if [[ $INSTALL_RESULT != 0 ]]; then echo "returned $INSTALL_RESULT"; node-pre-gyp unpublish; false; fi
+  - node-pre-gyp clean
+
+after_success:
+  - node-pre-gyp info

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,36 +1,52 @@
-# http://www.appveyor.com/docs/appveyor-yml
-
 clone_depth: 10
 
-version: "{build}"
-
-# What combinations to test
 environment:
+  node_pre_gyp_accessKeyId:
+    secure: 7nm7VvyIyBo9FKCCe3EeJfo06ms6mZSvkONjwS78Thw=
+  node_pre_gyp_secretAccessKey:
+    secure: mLU2PF28c0fKyjSFSSufKr7w/KwHCKQEouWPdJRUzNg6/yRiHc5SEU3BMkHzG18M
   matrix:
     - nodejs_version: "4"
       platform: x64
-    - nodejs_version: "4"
-      platform: x86
+      msvs_toolset: 12
+    # - nodejs_version: "4"
+    #   platform: x86
+    #   msvs_toolset: 12
     - nodejs_version: "6"
-      platform: x86
+      platform: x64
+      msvs_toolset: 12
+    # - nodejs_version: "6"
+    #   platform: x86
+    #   msvs_toolset: 12
     - nodejs_version: "7"
-      platform: x86
-
-install:
-  - git submodule update --init --recursive
-  - ps: Install-Product node $env:nodejs_version $env:platform
-  - IF "%platform%" == "x64" CALL "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" amd64
-  - IF "%platform%" == "x86" CALL "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x86
-  - npm install
-
-test_script:
-  - node --version && npm --version
-  - npm test
-
-build: off
+      platform: x64
+      msvs_toolset: 12
+    # - nodejs_version: "7"
+    #   platform: x86
+    #   msvs_toolset: 12
 
 matrix:
   fast_finish: true
 
-cache:
-  - node_modules -> package.json
+os: Visual Studio 2015
+
+install:
+  - cmd: SET PUBLISH_BINARY=false
+  - cmd: git describe --tags --always HEAD > _git_tag.tmp
+  - cmd: SET /p GIT_TAG=<_git_tag.tmp
+  - cmd: ECHO "LATEST LOCAL TAG:"
+  - cmd: ECHO %GIT_TAG%
+  - cmd: ECHO "APPVEYOR REPO BRANCH/TAG:"
+  - cmd: ECHO %APPVEYOR_REPO_BRANCH%
+  - cmd: DEL _git_tag.tmp
+  - cmd: SET COMMIT_MSG="%APPVEYOR_REPO_COMMIT_MESSAGE%"
+  - cmd: IF x%APPVEYOR_REPO_BRANCH%==x%GIT_TAG% SET PUBLISH_BINARY=true
+  - cmd: IF not x%COMMIT_MSG:[publish binary]=%==x%COMMIT_MSG% SET PUBLISH_BINARY=true
+  - cmd: ECHO "Env Var PUBLISH_BINARY:"
+  - cmd: ECHO %PUBLISH_BINARY%
+  - git submodule update --init --recursive
+  - scripts\build-appveyor.bat
+
+build: OFF
+test: OFF
+deploy: OFF

--- a/binding.gyp
+++ b/binding.gyp
@@ -55,6 +55,23 @@
       "xcode_settings": {
         "OTHER_CFLAGS" : ["-O2"]
       }
+    },
+    {
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [
+        "encode",
+        "decode"
+      ],
+      "copies": [
+        {
+          "files": [
+            "<(PRODUCT_DIR)/encode.node",
+            "<(PRODUCT_DIR)/decode.node"
+          ],
+          "destination": "<(module_path)"
+        }
+      ]
     }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ exports.decompressSync = decompressSync;
 exports.compressStream = compressStream;
 exports.decompressStream = decompressStream;
 
-var encode = require('./build/Release/encode.node');
-var decode = require('./build/Release/decode.node');
+var encode = require('./build/bindings/encode.node');
+var decode = require('./build/bindings/decode.node');
 var Transform = require('stream').Transform;
 var util = require('util');
 

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "index.js"
   ],
   "dependencies": {
-    "nan": "^2.4.0"
+    "nan": "^2.6.1"
   },
   "devDependencies": {
-    "expect.js": "^0.3.1",
-    "mocha": "^2.3.3"
+    "chai": "^3.5.0",
+    "mocha": "^3.2.0"
   },
   "scripts": {
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -29,15 +29,29 @@
     "binding.gyp",
     "index.js"
   ],
+  "bundledDependencies": [
+    "node-pre-gyp"
+  ],
   "dependencies": {
-    "nan": "^2.6.1"
+    "nan": "^2.6.1",
+    "node-pre-gyp": "^0.6.34"
   },
   "devDependencies": {
+    "aws-sdk": "^2.39.0",
     "chai": "^3.5.0",
     "mocha": "^3.2.0"
   },
   "scripts": {
+    "prepublish": "npm ls",
+    "install": "node-pre-gyp install --fallback-to-build",
     "test": "mocha"
+  },
+  "binary": {
+    "module_name": "encode",
+    "module_path": "./build/bindings",
+    "remote_path": "./{name}/v{version}/{toolset}/",
+    "package_name": "{node_abi}-{platform}-{arch}.tar.gz",
+    "host": "https://node-iltorb.s3.amazonaws.com"
   },
   "license": "MIT"
 }

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -1,0 +1,158 @@
+@ECHO OFF
+SETLOCAL
+SET EL=0
+
+ECHO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ %~f0 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SET PATH=%CD%;%PATH%
+SET msvs_version=2013
+IF "%msvs_toolset%"=="14" SET msvs_version=2015
+
+ECHO APPVEYOR^: %APPVEYOR%
+ECHO nodejs_version^: %nodejs_version%
+ECHO platform^: %platform%
+ECHO msvs_toolset^: %msvs_toolset%
+ECHO msvs_version^: %msvs_version%
+ECHO TOOLSET_ARGS^: %TOOLSET_ARGS%
+
+
+ECHO activating VS command prompt
+:: NOTE this call makes the x64 -> X64
+IF /I "%platform%"=="x64" ECHO x64 && CALL "C:\Program Files (x86)\Microsoft Visual Studio %msvs_toolset%.0\VC\vcvarsall.bat" amd64
+IF /I "%platform%"=="x86" ECHO x86 && CALL "C:\Program Files (x86)\Microsoft Visual Studio %msvs_toolset%.0\VC\vcvarsall.bat" x86
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+ECHO using compiler^: && CALL cl
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+ECHO using MSBuild^: && CALL msbuild /version && ECHO.
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+
+ECHO downloading/installing node
+::only use Install-Product when using VS2013
+::IF /I "%APPVEYOR%"=="True" IF /I "%msvs_toolset%"=="12" powershell Install-Product node $env:nodejs_version $env:Platform
+::TESTING:
+::always install (get npm matching node), but delete installed programfiles node.exe afterwards for VS2015 (using custom node.exe)
+IF /I "%APPVEYOR%"=="True" GOTO APPVEYOR_INSTALL
+GOTO SKIP_APPVEYOR_INSTALL
+
+:APPVEYOR_INSTALL
+IF /I "%platform%"=="x64" powershell Install-Product node $env:nodejs_version x64
+IF /I "%platform%"=="x86" powershell Install-Product node $env:nodejs_version x86
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+SET NODE_MAJOR=%nodejs_version:~0,1%
+ECHO node major version^: %NODE_MAJOR%
+IF %NODE_MAJOR% GTR 0 ECHO node version greater than zero, not updating npm && GOTO SKIP_APPVEYOR_INSTALL
+
+powershell Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+CALL npm install --global --production npm-windows-upgrade
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+REM error C2373: '__pfnDliNotifyHook2': redefinition; different type modifiers
+REM at least 2.15.9 is needed: https://github.com/nodejs/node-gyp/issues/972#issuecomment-231055109
+CALL npm-windows-upgrade --npm-version 2.15.9 --no-dns-check --no-prompt
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+:SKIP_APPVEYOR_INSTALL
+IF /I "%msvs_toolset%"=="12" GOTO NODE_INSTALLED
+
+::custom node for VS2015
+SET ARCHPATH=
+IF "%platform%"=="X64" (SET ARCHPATH=x64/)
+IF "%platform%"=="x64" (SET ARCHPATH=x64/)
+SET NODE_URL=https://mapbox.s3.amazonaws.com/node-cpp11/v%nodejs_version%/%ARCHPATH%node.exe
+ECHO downloading node^: %NODE_URL%
+powershell Invoke-WebRequest "${env:NODE_URL}" -OutFile node.exe
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+ECHO deleting node ...
+SET NODE_EXE_PRG=%ProgramFiles%\nodejs\node.exe
+IF EXIST "%NODE_EXE_PRG%" ECHO found %NODE_EXE_PRG%, deleting... && DEL /F "%NODE_EXE_PRG%"
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+IF EXIST "%ProgramFiles%\nodejs" ECHO copy custom node.exe to %ProgramFiles%\nodejs\ && COPY node.exe "%ProgramFiles%\nodejs\"
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+SET NODE_EXE_PRG=%ProgramFiles(x86)%\nodejs\node.exe
+IF EXIST "%NODE_EXE_PRG%" ECHO found %NODE_EXE_PRG%, deleting... && DEL /F "%NODE_EXE_PRG%"
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+IF EXIST "%ProgramFiles(x86)%\nodejs" ECHO copy custom node.exe to %ProgramFiles(x86)%\nodejs\ && COPY node.exe "%ProgramFiles(x86)%\nodejs\"
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+ECHO delete node.exe in current directory && DEL node.exe
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+:NODE_INSTALLED
+
+ECHO available node.exe^:
+call where node
+ECHO available npm^:
+call where npm
+
+ECHO node^: && call node -v
+call node -e "console.log('  - arch:',process.arch,'\n  - argv:',process.argv,'\n  - execPath:',process.execPath)"
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+ECHO npm^: && CALL npm -v
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+ECHO ===== where npm puts stuff START ============
+ECHO npm root && CALL npm root
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+ECHO npm root -g && CALL npm root -g
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+ECHO npm bin && CALL npm bin
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+ECHO npm bin -g && CALL npm bin -g
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+SET NPM_BIN_DIR=
+FOR /F "tokens=*" %%i in ('CALL npm bin -g') DO SET NPM_BIN_DIR=%%i
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+IF /I "%NPM_BIN_DIR%"=="%CD%" ECHO ERROR npm bin -g equals local directory && SET ERRORLEVEL=1 && GOTO ERROR
+ECHO ===== where npm puts stuff END ============
+
+CALL
+
+ECHO installing node-gyp
+CALL npm install -g node-gyp
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+CALL npm install --build-from-source --msvs_version=%msvs_version% %TOOLSET_ARGS% --loglevel=http
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+::skipping check for errorlevel npm test result when using io.js
+::@springmeyer: how to proceed?
+IF NOT "%nodejs_version%"=="1.8.1" IF NOT "%nodejs_version%"=="2.0.0" GOTO CHECK_NPM_TEST_ERRORLEVEL
+
+ECHO calling npm test
+CALL npm test
+GOTO NPM_TEST_FINISHED
+
+
+:CHECK_NPM_TEST_ERRORLEVEL
+ECHO calling npm test
+CALL npm test
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+:NPM_TEST_FINISHED
+
+CALL node_modules\.bin\node-pre-gyp package %TOOLSET_ARGS%
+::make commit message env var shorter
+SET CM=%APPVEYOR_REPO_COMMIT_MESSAGE%
+IF /I "%PUBLISH_BINARY%"=="true" (ECHO publishing && CALL node_modules\.bin\node-pre-gyp --msvs_version=%msvs_version% publish %TOOLSET_ARGS%) ELSE (ECHO not publishing)
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+GOTO DONE
+
+:ERROR
+ECHO ~~~~~~~~~~~~~~~~~~~~~~ ERROR %~f0 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ECHO ERRORLEVEL^: %ERRORLEVEL%
+SET EL=%ERRORLEVEL%
+
+:DONE
+ECHO ~~~~~~~~~~~~~~~~~~~~~~ DONE %~f0 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+EXIT /b %EL%

--- a/test/brotliBufferAsync.js
+++ b/test/brotliBufferAsync.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var brotli = require('../');
-var expect = require('expect.js');
+var chai = require('chai');
+var expect = chai.expect;
 var fs = require('fs');
 var path = require('path');
 
@@ -12,14 +13,14 @@ function testBufferAsync(method, bufferFile, resultFile, done, params) {
 
   if (method.name === 'compress') {
     method(buffer, params, function(err, output) {
-      expect(output).to.eql(result);
+      expect(output).to.deep.equal(result);
       done();
     });
   }
 
   if (method.name === 'decompress') {
     method(buffer, function(err, output) {
-      expect(output).to.eql(result);
+      expect(output).to.deep.equal(result);
       done();
     });
   }

--- a/test/brotliBufferSync.js
+++ b/test/brotliBufferSync.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var brotli = require('../');
-var expect = require('expect.js');
+var chai = require('chai');
+var expect = chai.expect;
 var fs = require('fs');
 var path = require('path');
 
@@ -10,7 +11,7 @@ function testBufferSync(method, bufferFile, resultFile, params) {
   var buffer = fs.readFileSync(path.join(__dirname, '/fixtures/', bufferFile));
   var result = fs.readFileSync(path.join(__dirname, '/fixtures/', resultFile));
   var output = method(buffer, params);
-  expect(output).to.eql(result);
+  expect(output).to.deep.equal(result);
 }
 
 describe('Brotli Buffer Sync', function() {

--- a/test/brotliStream.js
+++ b/test/brotliStream.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var brotli = require('../');
-var expect = require('expect.js');
+var chai = require('chai');
+var expect = chai.expect;
 var Writable = require('stream').Writable;
 var util = require('util');
 var fs = require('fs');
@@ -27,7 +28,7 @@ function testStream(method, bufferFile, resultFile, done, params) {
 
   writeStream.on('finish', function() {
     var result = fs.readFileSync(path.join(__dirname, '/fixtures/', resultFile));
-    expect(writeStream.data).to.eql(result);
+    expect(writeStream.data).to.deep.equal(result);
     done();
   });
 }


### PR DESCRIPTION
This should address #17 and possibly #24 (we still don't have any error logs provided for that one). Also cuts down install time since we won't need to compile it every time and can use pre-built binaries instead.

Automates the publishing of pre-built binaries to S3 for the following environments:

| OS     | Node  | Toolset |x86 | x64 |
| ------ |--------|---------|:----:|:----:|
| Linux | `v4.x.x` |            | ✖ | ✔ |
| Linux | `v6.x.x` |            | ✖ | ✔ |
| Linux | `v7.x.x` |            | ✖ | ✔ |
| Windows | `v4.x.x` | `MSVS=12` | ✖ | ✔ |
| Windows | `v6.x.x` | `MSVS=12` | ✖ | ✔ |
| Windows | `v7.x.x` | `MSVS=12` | ✖ | ✔ |

Disabled the tests for `x86` on Windows/AppVeyor because those tests are still randomly failing for some reason. Will need to take a look into them again and also expand our build matrix later. This should hopefully resolve some of those build errors that people have been reporting on Windows though.

To publish, we just need to do one of the following:
- add `[publish binary]` to a commit message
- create a `tag` release