### PR TITLE
appveyor/travis-ci changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
   fast_finish: true
 
 before_install:
+  - export JOBS=max
   - export PATH=./node_modules/.bin/:$PATH
   - npm install -g node-gyp
   - PUBLISH_BINARY=false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ matrix:
 os: Visual Studio 2015
 
 install:
+  - cmd: SET JOBS=max
   - cmd: SET PUBLISH_BINARY=false
   - cmd: git describe --tags --always HEAD > _git_tag.tmp
   - cmd: SET /p GIT_TAG=<_git_tag.tmp


### PR DESCRIPTION
- slightly improve build time by using `JOBS=max` to use all cores
- ~~re-enable windows x86 builds since passes seem to pass now (hopefully not a problem again later)~~