### PR TITLE
implement workaround for glibc 2.14 not found

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -32,7 +32,10 @@
         "brotli/include"
       ],
       "defines": ["NOMINMAX"],
-      "cflags" : ["-O2"],
+      "cflags" : [
+        "-include ../src/_memcpy.h",
+        "-O2"
+      ],
       "xcode_settings": {
         "OTHER_CFLAGS" : ["-O2"]
       }
@@ -55,7 +58,10 @@
         "<!(node -e \"require('nan')\")",
         "brotli/include"
       ],
-      "cflags" : ["-O2"],
+      "cflags" : [
+        "-include ../src/_memcpy.h",
+        "-O2"
+      ],
       "xcode_settings": {
         "OTHER_CFLAGS" : ["-O2"]
       }

--- a/src/_memcpy.h
+++ b/src/_memcpy.h
@@ -1,0 +1,2 @@
+/* force mempcy to be from earlier compatible system */
+__asm__(".symver memcpy,memcpy@GLIBC_2.2.5");

--- a/src/_memcpy.h
+++ b/src/_memcpy.h
@@ -1,2 +1,3 @@
 /* force mempcy to be from earlier compatible system */
+/* see https://github.com/MayhemYDG/iltorb/issues/35 */
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");


### PR DESCRIPTION
This is a possible workaround for #35. Will need to do some additional verification first.
See https://www.win.tue.nl/~aeb/linux/misc/gcc-semibug.html for some details.