### PR TITLE
Update node-pre-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "nan": "^2.6.2",
-    "node-pre-gyp": "0.6.35"
+    "node-pre-gyp": "0.6.38"
   },
   "devDependencies": {
     "chai": "^4.1.1",


### PR DESCRIPTION
The current version of node-pre-gyp has dependencies vulnerable to regex DoS. Updating to the latest version.