### PR TITLE
Make the compress/decompress methods return a promise when the callback is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### Added
+- The compress and decompress methods will now return a promise when the callback argument is missing.
+  - This change enables using those methods in async/await flow.
+
 ## [2.2.0] - 2018-03-30
 ### Changed
 - Updated brotli from [v1.0.3] to [v1.0.4]

--- a/README.md
+++ b/README.md
@@ -26,24 +26,52 @@ The following is required to build from source or when a [pre-compiled binary](h
 
 ### Async
 
-#### compress(buffer[, brotliEncodeParams], callback)
+Omitting the callback argument will result in the compress and decompress methods to return a Promise.
+
+#### compress(buffer[, brotliEncodeParams][, callback])
 
 ```javascript
 const compress = require('iltorb').compress;
 
+// callback style
 compress(input, function(err, output) {
   // ...
 });
+
+// promise style
+compress(input)
+  .then(output => /* ... */)
+  .catch(err => /* ... */);
+
+// async/await style
+try {
+  const output = await compress(input);
+} catch(err) {
+  // ...
+}
 ```
 
-#### decompress(buffer, callback)
+#### decompress(buffer[, callback])
 
 ```javascript
 const decompress = require('iltorb').decompress;
 
+// callback style
 decompress(input, function(err, output) {
   // ...
 });
+
+// promise style
+decompress(input)
+  .then(output => /* ... */)
+  .catch(err => /* ... */);
+
+// async/await style
+try {
+  const output = await decompress(input);
+} catch(err) {
+  // ...
+}
 ```
 
 ### Sync

--- a/test/brotliBufferPromise.js
+++ b/test/brotliBufferPromise.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const brotli = require('../');
+const chai = require('chai');
+const expect = chai.expect;
+const fs = require('fs');
+const path = require('path');
+
+function testBufferPromise(method, bufferFile, resultFile, done, params) {
+  params = params || {};
+  const buffer = fs.readFileSync(path.join(__dirname, '/fixtures/', bufferFile));
+  const result = fs.readFileSync(path.join(__dirname, '/fixtures/', resultFile));
+
+  if (method.name === 'compress') {
+    method(buffer, params).then(function(output) {
+      expect(output).to.deep.equal(result);
+      done();
+    });
+  }
+
+  if (method.name === 'decompress') {
+    method(buffer).then(function(output) {
+      expect(output).to.deep.equal(result);
+      done();
+    });
+  }
+}
+
+describe('Brotli Buffer Promise', function() {
+  describe('compress', function() {
+    it('should compress binary data', function(done) {
+      testBufferPromise(brotli.compress, 'data10k.bin', 'data10k.bin.compressed', done);
+    });
+
+    it('should compress text data', function(done) {
+      testBufferPromise(brotli.compress, 'data.txt', 'data.txt.compressed', done);
+    });
+
+    it('should compress text data with quality=3', function(done) {
+      testBufferPromise(brotli.compress, 'data.txt', 'data.txt.compressed.03', done, { quality: 3 });
+    });
+
+    it('should compress text data with quality=9', function(done) {
+      testBufferPromise(brotli.compress, 'data.txt', 'data.txt.compressed.09', done, { quality: 9 });
+    });
+
+    it('should compress an empty buffer', function(done) {
+      testBufferPromise(brotli.compress, 'empty', 'empty.compressed', done);
+    });
+
+    it('should compress a random buffer', function(done) {
+      this.timeout(30000);
+      testBufferPromise(brotli.compress, 'rand', 'rand.compressed', done);
+    });
+
+    it('should compress a large buffer', function(done) {
+      if (process.env.SKIP_LARGE_BUFFER_TEST) {
+        this.skip();
+      }
+
+      this.timeout(30000);
+      testBufferPromise(brotli.compress, 'large.txt', 'large.txt.compressed', done);
+    });
+  });
+
+  describe('decompress', function() {
+    it('should decompress binary data', function(done) {
+      testBufferPromise(brotli.decompress, 'data10k.bin.compressed', 'data10k.bin', done);
+    });
+
+    it('should decompress text data', function(done) {
+      testBufferPromise(brotli.decompress, 'data.txt.compressed', 'data.txt', done);
+    });
+
+    it('should decompress to an empty buffer', function(done) {
+      testBufferPromise(brotli.decompress, 'empty.compressed', 'empty', done);
+    });
+
+    it('should decompress a random buffer', function(done) {
+      testBufferPromise(brotli.decompress, 'rand.compressed', 'rand', done);
+    });
+
+    it('should decompress to a large buffer', function(done) {
+      this.timeout(30000);
+      testBufferPromise(brotli.decompress, 'large.compressed', 'large', done);
+    });
+
+    it('should decompress to another large buffer', function(done) {
+      if (process.env.SKIP_LARGE_BUFFER_TEST) {
+        this.skip();
+      }
+
+      this.timeout(30000);
+      testBufferPromise(brotli.decompress, 'large.txt.compressed', 'large.txt', done);
+    });
+  });
+});


### PR DESCRIPTION
I was thinking about perhaps returning a non-rejecting promise like this instead:
```js
const [err, output] = await method(input);
```
so users can avoid try/catch blocks, but I feel like it might be less ideal for promise chains.
It also wouldn't reject a `Promise.all()` call immediately once an error pops up.
That's why I think it's better to follow the usual practice.