### PR TITLE
Remove unused exec in scripts/build.js

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,5 @@
 const libc = require('detect-libc');
 const getTarget = require('node-abi').getTarget;
-const exec = require('child_process').exec;
 const spawn = require('cross-spawn');
 const npmRunPath = require('npm-run-path-compat');
 


### PR DESCRIPTION
This PR is a tiny drive-by cleanliness task. `exec` appears to be unused, and flagged in a code checking tool I used. Figured I'd tidy up 👍 