### PR TITLE
fix CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ config_steps: &config_steps
             yum -y install devtoolset-7-gcc devtoolset-7-gcc-c++ git make
             yum -y groupinstall 'Development Tools'
             yum -y install nodejs
-            echo 'export PATH=/opt/rh/devtoolset-3/root/usr/bin/:$PATH' >> $BASH_ENV
+            echo 'export PATH=/opt/rh/devtoolset-7/root/usr/bin/:$PATH' >> $BASH_ENV
           fi
 
     - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ config_steps: &config_steps
             yum -y install centos-release-scl-rh epel-release
             yum -y install http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
             yum -y install devtoolset-6-gcc devtoolset-6-gcc-c++ git make
+            yum -y groupinstall 'Development Tools'
             yum -y install nodejs
             echo 'export PATH=/opt/rh/devtoolset-3/root/usr/bin/:$PATH' >> $BASH_ENV
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ config_steps: &config_steps
             curl --silent --location "https://rpm.nodesource.com/setup_${NODEJS}.x" | bash -
             yum -y install centos-release-scl-rh epel-release
             yum -y install http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
-            yum -y install devtoolset-6-gcc devtoolset-6-gcc-c++ git make
+            yum -y install devtoolset-7-gcc devtoolset-7-gcc-c++ git make
             yum -y groupinstall 'Development Tools'
             yum -y install nodejs
             echo 'export PATH=/opt/rh/devtoolset-3/root/usr/bin/:$PATH' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,6 @@ config_steps: &config_steps
           if [[ $DISTRO == "CENTOS" ]]; then
             curl --silent --location "https://rpm.nodesource.com/setup_${NODEJS}.x" | bash -
             yum -y install centos-release-scl-rh epel-release
-            yum -y install http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
-            yum -y install devtoolset-7-gcc devtoolset-7-gcc-c++ git make
             yum -y groupinstall 'Development Tools'
             yum -y install nodejs
             echo 'export PATH=/opt/rh/devtoolset-7/root/usr/bin/:$PATH' >> $BASH_ENV
@@ -57,7 +55,7 @@ jobs:
   "node-6":
     <<: *config_steps
     docker:
-      - image: centos:6.6
+      - image: centos:7
         environment:
           DISTRO: CENTOS
           NODEJS: 6
@@ -65,7 +63,7 @@ jobs:
   "node-8":
     <<: *config_steps
     docker:
-      - image: centos:6.6
+      - image: centos:7
         environment:
           DISTRO: CENTOS
           NODEJS: 8
@@ -73,7 +71,7 @@ jobs:
   "node-10":
     <<: *config_steps
     docker:
-      - image: centos:6.6
+      - image: centos:7
         environment:
           DISTRO: CENTOS
           NODEJS: 10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ config_steps: &config_steps
             curl --silent --location "https://rpm.nodesource.com/setup_${NODEJS}.x" | bash -
             yum -y install centos-release-scl-rh epel-release
             yum -y install http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
-            yum -y install devtoolset-3-gcc devtoolset-3-gcc-c++ git make
+            yum -y install devtoolset-6-gcc devtoolset-6-gcc-c++ git make
             yum -y install nodejs
             echo 'export PATH=/opt/rh/devtoolset-3/root/usr/bin/:$PATH' >> $BASH_ENV
           fi

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,9 +3,9 @@ const getTarget = require('node-abi').getTarget;
 const spawn = require('cross-spawn');
 const npmRunPath = require('npm-run-path-compat');
 
+const ENV = npmRunPath.env();
 const PREBUILD_TOKEN = process.env.PREBUILD_TOKEN;
 const PUBLISH_BINARY = process.env.PUBLISH_BINARY || false;
-
 
 function build({target, runtime, abi}) {
   try {
@@ -25,6 +25,8 @@ function build({target, runtime, abi}) {
   }
 
   return new Promise((resolve, reject) => {
+    // re-create PATH to ensure that system binaries take precendence over NODE binaries
+    const env = Object.assign({}, ENV, { PATH: `${process.env.PATH}:${ENV.PATH}` })
     const proc = spawn('prebuild', args, { env: npmRunPath.env() });
 
     proc.stdout.pipe(process.stdout);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,7 +3,6 @@ const getTarget = require('node-abi').getTarget;
 const spawn = require('cross-spawn');
 const npmRunPath = require('npm-run-path-compat');
 
-const ENV = npmRunPath.env();
 const PREBUILD_TOKEN = process.env.PREBUILD_TOKEN;
 const PUBLISH_BINARY = process.env.PUBLISH_BINARY || false;
 
@@ -25,8 +24,6 @@ function build({target, runtime, abi}) {
   }
 
   return new Promise((resolve, reject) => {
-    // re-create PATH to ensure that system binaries take precendence over NODE binaries
-    const env = Object.assign({}, ENV, { PATH: `${process.env.PATH}:${ENV.PATH}` })
     const proc = spawn('prebuild', args, { env: npmRunPath.env() });
 
     proc.stdout.pipe(process.stdout);


### PR DESCRIPTION
It seems that our builds on the Centos distro is broken since the `devtoolset-3` packages are no longer available for some reason. Tried it with `devtoolset-7` since those packages are available, but ran into issues with the final build artifacts. Ended up bumping Centos 6 to Centos 7.