### PR TITLE
fix CI build pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ config_steps: &config_steps
             echo 'export PUBLISH="true"' >> $BASH_ENV
           fi
 
-    - run: npm install -g node-gyp
+    - run: npm install -g node-gyp --unsafe-perm
     - run: npm install --build-from-source --unsafe-perm
     - run: npm test
     - run: npm run prebuild-ci


### PR DESCRIPTION
This updates our CI config to install `node-gyp` with the `--unsafe-perm` flag as a workaround the an issue where global installs are returning the following error:

```
Error: could not get uid/gid
[ 'nobody', 0 ]
```

This seems to be happening only on our Alpine images for Node 8 and 10.