### PR TITLE
Fix Node 11 builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,9 @@ environment:
     secure: 7t92yForo995jn/5Afeo6A3wcmEyus0nlybU4a9MYQ1FSoMvkjLeihbEQYr99F9S
 
   matrix:
+    - nodejs_version: "6"
+    - nodejs_version: "8"
+    - nodejs_version: "10"
     - nodejs_version: "11"
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,9 @@ artifacts:
 
 install:
   - cmd: git submodule update --init --recursive
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:platform;
+  - ps: Install-Product node $env:nodejs_version $env:platform;
+  - node --version
+  - npm --version
   - ps: >
       $env:JOBS = "max";
       $env:PUBLISH = "false";

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,9 +28,6 @@ install:
   - cmd: git submodule update --init --recursive
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:platform;
   - ps: >
-      npm config set progress false
-      npm config set spin false
-  - ps: >
       $env:JOBS = "max";
       $env:PUBLISH = "false";
       $env:GIT_TAG = "$(git describe --tags --always HEAD)";

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,6 @@ environment:
     secure: 7t92yForo995jn/5Afeo6A3wcmEyus0nlybU4a9MYQ1FSoMvkjLeihbEQYr99F9S
 
   matrix:
-    - nodejs_version: "6"
-    - nodejs_version: "8"
-    - nodejs_version: "10"
     - nodejs_version: "11"
 
 platform:


### PR DESCRIPTION
This changes our AppVeyor build config to use `Install-Product` instead of `Update-NodeJsInstallation`. It should speed up our builds by quite a bit since it's just switching the version to the latest one available on the image. This also resolves the issue we've been having with `npm` not being available as well.